### PR TITLE
Update dependency checks to rely on patch version instead of major.minor

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -572,7 +572,7 @@ begin
 
 #ifdef UseNetCore31
   // https://dotnet.microsoft.com/download/dotnet-core/3.1
-  if not IsNetCoreInstalled('Microsoft.NETCore.App 3.1.0') then begin
+  if not IsNetCoreInstalled('Microsoft.NETCore.App 3.1.10') then begin
     AddDependency('netcore31' + GetArchitectureSuffix + '.exe',
       '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
       '.NET Core Runtime 3.1.10' + GetArchitectureTitle,
@@ -583,7 +583,7 @@ begin
 
 #ifdef UseNetCore31Asp
   // https://dotnet.microsoft.com/download/dotnet-core/3.1
-  if not IsNetCoreInstalled('Microsoft.AspNetCore.App 3.1.0') then begin
+  if not IsNetCoreInstalled('Microsoft.AspNetCore.App 3.1.10') then begin
     AddDependency('netcore31asp' + GetArchitectureSuffix + '.exe',
       '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
       'ASP.NET Core Runtime 3.1.10' + GetArchitectureTitle,
@@ -594,7 +594,7 @@ begin
 
 #ifdef UseNetCore31Desktop
   // https://dotnet.microsoft.com/download/dotnet-core/3.1
-  if not IsNetCoreInstalled('Microsoft.WindowsDesktop.App 3.1.0') then begin
+  if not IsNetCoreInstalled('Microsoft.WindowsDesktop.App 3.1.10') then begin
     AddDependency('netcore31desktop' + GetArchitectureSuffix + '.exe',
       '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
       '.NET Desktop Runtime 3.1.10' + GetArchitectureTitle,
@@ -605,7 +605,7 @@ begin
 
 #ifdef UseDotNet50
   // https://dotnet.microsoft.com/download/dotnet/5.0
-  if not IsNetCoreInstalled('Microsoft.NETCore.App 5.0.0') then begin
+  if not IsNetCoreInstalled('Microsoft.NETCore.App 5.0.1') then begin
     AddDependency('dotnet50' + GetArchitectureSuffix + '.exe',
       '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
       '.NET Runtime 5.0.1' + GetArchitectureTitle,
@@ -616,7 +616,7 @@ begin
 
 #ifdef UseDotNet50Asp
   // https://dotnet.microsoft.com/download/dotnet/5.0
-  if not IsNetCoreInstalled('Microsoft.AspNetCore.App 5.0.0') then begin
+  if not IsNetCoreInstalled('Microsoft.AspNetCore.App 5.0.1') then begin
     AddDependency('dotnet50asp' + GetArchitectureSuffix + '.exe',
       '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
       'ASP.NET Core Runtime 5.0.1' + GetArchitectureTitle,
@@ -627,7 +627,7 @@ begin
 
 #ifdef UseDotNet50Desktop
   // https://dotnet.microsoft.com/download/dotnet/5.0
-  if not IsNetCoreInstalled('Microsoft.WindowsDesktop.App 5.0.0') then begin
+  if not IsNetCoreInstalled('Microsoft.WindowsDesktop.App 5.0.1') then begin
     AddDependency('dotnet50desktop' + GetArchitectureSuffix + '.exe',
       '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
       '.NET Desktop Runtime 5.0.1' + GetArchitectureTitle,


### PR DESCRIPTION
### Introduction
According to the [NET Core Releases and Support](https://devblogs.microsoft.com/dotnet/net-core-releases-and-support/) page, monthly service updates provide important security fixes:

![image](https://user-images.githubusercontent.com/59936622/102143369-b57df480-3e18-11eb-92f4-5a8f26770240.png)

In addition, older servicing updates are no longer supported as soon as a newer version is released:

![image](https://user-images.githubusercontent.com/59936622/102143558-f6760900-3e18-11eb-95e3-efa224cc6b65.png)

Developers who are using this repository to install .NET Core/.NET 5 as a dependency need their apps to install the latest version of .NET Core/.NET 5 in order to qualify for support. It is also important for the users installing these applications to have the most up to date and secure version of .NET Core/.NET 5 installed possible.

### Problem
Currently, the default dependency detection behavior relies on just the major.minor versions. For example, we only check if at least Microsoft.NETCore.App 3.1.0 is installed instead of Microsoft.NETCore.App 3.1.10. What this means is that users who have Microsoft.NETCore.App 3.1.5 installed will continue to use this unsupported and insecure version of .NET Core.

### Solution
Instead, we can enforce checking for the latest version of .NET Core/.NET 5 by default. If the latest version is not installed, we install it. For example, if a user has Microsoft.NETCore.App 3.1.9 installed, they will be upgraded to Microsoft.NETCore.App 3.1.10.

### Demo
![patch](https://user-images.githubusercontent.com/59936622/102144426-4f926c80-3e1a-11eb-8759-8cef3d834271.gif)