### PR TITLE
Introduce the notion of external installs

### DIFF
--- a/CodeDependencies.iss
+++ b/CodeDependencies.iss
@@ -20,6 +20,7 @@ type
     Checksum: String;
     ForceSuccess: Boolean;
     RestartAfter: Boolean;
+    ExternalInstall: Boolean;
   end;
 
 var
@@ -27,13 +28,87 @@ var
   Dependency_List: array of TDependency_Entry;
   Dependency_NeedRestart, Dependency_ForceX86: Boolean;
   Dependency_DownloadPage: TDownloadWizardPage;
+  Dependency_ExternalInstallCount: Integer;
+  Dependency_ExternalInstallPage: TWizardPage;
 
-procedure Dependency_Add(const Filename, Parameters, Title, URL, Checksum: String; const ForceSuccess, RestartAfter: Boolean);
+procedure Dependency_URLLabelClick(Sender: TObject);
+var
+  URL: string;
+  ErrorCode: Integer;
+begin
+  URL := TNewStaticText(Sender).Caption;
+  ShellExecAsOriginalUser('', URL, '', '', SW_SHOW, ewNoWait, ErrorCode);  
+end; 
+  
+procedure Dependency_ExternalInstallPageActivate(Sender: TWizardPage);
+var
+  NextTop: Integer;
+  DescLeft: Integer;
+  UrlLeft: Integer;
+  LabelWidth: Integer;
+  DependencyCount: Integer;
+  DependencyIndex: Integer;
+  Dependency: TDependency_Entry;
+  NewDescLabel: TNewStaticText;
+  NewURLLabel: TNewStaticText;
+begin
+  WizardForm.NextButton.Enabled := False;
+  WizardForm.BackButton.Enabled := False;
+  WizardForm.CancelButton.Caption := SetupMessage(msgButtonFinish);
+  
+  NextTop := 0;
+  DescLeft := 0;
+  UrlLeft := Dependency_ExternalInstallPage.SurfaceWidth div 2; 
+  LabelWidth := (Dependency_ExternalInstallPage.SurfaceWidth div 2) - ScaleX(10); 
+  DependencyCount := GetArrayLength(Dependency_List);
+  for DependencyIndex := 0 to DependencyCount - 1 do begin
+    Dependency := Dependency_List[DependencyIndex];
+    if Dependency.ExternalInstall then begin
+      NewDescLabel := TNewStaticText.Create(Dependency_ExternalInstallPage);
+      NewDescLabel.AutoSize := False;
+      NewDescLabel.WordWrap := False;
+      NewDescLabel.Left := DescLeft; 
+      NewDescLabel.Top := NextTop;
+      NewDescLabel.Width := LabelWidth;
+      NewDescLabel.Caption := Dependency.Title;
+      NewDescLabel.Parent := Dependency_ExternalInstallPage.Surface;
+
+      NewURLLabel := TNewStaticText.Create(Dependency_ExternalInstallPage);
+      NewURLLabel.AutoSize := False;
+      NewURLLabel.WordWrap := False;
+      NewURLLabel.Left := UrlLeft; 
+      NewURLLabel.Top := NextTop;
+      NewURLLabel.Width := LabelWidth;
+      NewURLLabel.Caption := Dependency.URL;
+      NewURLLabel.OnClick := @Dependency_URLLabelClick;
+      NewURLLabel.Cursor := crHand;
+      NewURLLabel.Parent := Dependency_ExternalInstallPage.Surface;
+      NewURLLabel.Font.Color := clBlue; // change font after setting parent to get valid default values
+      NewURLLabel.Font.Style := NewURLLabel.Font.Style + [fsUnderline];
+      
+      NextTop := NextTop + Trunc(NewDescLabel.Height * 1.5);
+    end;
+  end;
+end;
+
+procedure Dependency_CreateExternalInstallPageIfNeeded;
+begin
+  if (Dependency_ExternalInstallCount > 0) and not Assigned(Dependency_ExternalInstallPage) then begin
+    Dependency_ExternalInstallPage := CreateCustomPage(wpSelectTasks, CustomMessage('externalinstall_title'), CustomMessage('externalinstall_description'));
+    Dependency_ExternalInstallPage.OnActivate := @Dependency_ExternalInstallPageActivate;
+  end;
+end;
+
+procedure Dependency_AddEx(const Filename, Parameters, Title, URL, Checksum: String; const ForceSuccess, RestartAfter, ExternalInstall: Boolean);
 var
   Dependency: TDependency_Entry;
   DependencyCount: Integer;
 begin
-  Dependency_Memo := Dependency_Memo + #13#10 + '%1' + Title;
+  if ExternalInstall then begin
+    Inc(Dependency_ExternalInstallCount)
+  end else begin
+    Dependency_Memo := Dependency_Memo + #13#10 + '%1' + Title;
+  end;
 
   Dependency.Filename := Filename;
   Dependency.Parameters := Parameters;
@@ -48,10 +123,16 @@ begin
   Dependency.Checksum := Checksum;
   Dependency.ForceSuccess := ForceSuccess;
   Dependency.RestartAfter := RestartAfter;
+  Dependency.ExternalInstall := ExternalInstall;
 
   DependencyCount := GetArrayLength(Dependency_List);
   SetArrayLength(Dependency_List, DependencyCount + 1);
   Dependency_List[DependencyCount] := Dependency;
+end;
+
+procedure Dependency_Add(const Filename, Parameters, Title, URL, Checksum: String; const ForceSuccess, RestartAfter: Boolean);
+begin
+  Dependency_AddEx(Filename, Parameters, Title, URL, Checksum, ForceSuccess, RestartAfter, False);
 end;
 
 <event('InitializeWizard')>
@@ -70,10 +151,11 @@ begin
   DependencyCount := GetArrayLength(Dependency_List);
 
   if DependencyCount > 0 then begin
-    Dependency_DownloadPage.Show;
+    if DependencyCount - Dependency_ExternalInstallCount > 0 then
+      Dependency_DownloadPage.Show;
 
     for DependencyIndex := 0 to DependencyCount - 1 do begin
-      if Dependency_List[DependencyIndex].URL <> '' then begin
+      if not Dependency_List[DependencyIndex].ExternalInstall and (Dependency_List[DependencyIndex].URL <> '') then begin
         Dependency_DownloadPage.Clear;
         Dependency_DownloadPage.Add(Dependency_List[DependencyIndex].URL, Dependency_List[DependencyIndex].Filename, Dependency_List[DependencyIndex].Checksum);
 
@@ -105,45 +187,47 @@ begin
 
     if Result = '' then begin
       for DependencyIndex := 0 to DependencyCount - 1 do begin
-        Dependency_DownloadPage.SetText(Dependency_List[DependencyIndex].Title, '');
-        Dependency_DownloadPage.SetProgress(DependencyIndex + 1, DependencyCount + 1);
+        if not Dependency_List[DependencyIndex].ExternalInstall then begin
+          Dependency_DownloadPage.SetText(Dependency_List[DependencyIndex].Title, '');
+          Dependency_DownloadPage.SetProgress(DependencyIndex + 1, DependencyCount + 1);
 
-        while True do begin
-          ResultCode := 0;
-          if ShellExec('', ExpandConstant('{tmp}{\}') + Dependency_List[DependencyIndex].Filename, Dependency_List[DependencyIndex].Parameters, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode) then begin
-            if Dependency_List[DependencyIndex].RestartAfter then begin
-              if DependencyIndex = DependencyCount - 1 then begin
-                Dependency_NeedRestart := True;
-              end else begin
+          while True do begin
+            ResultCode := 0;
+            if ShellExec('', ExpandConstant('{tmp}{\}') + Dependency_List[DependencyIndex].Filename, Dependency_List[DependencyIndex].Parameters, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ResultCode) then begin
+              if Dependency_List[DependencyIndex].RestartAfter then begin
+                if DependencyIndex = DependencyCount - 1 then begin
+                  Dependency_NeedRestart := True;
+                end else begin
+                  NeedsRestart := True;
+                  Result := Dependency_List[DependencyIndex].Title;
+                end;
+                break;
+              end else if (ResultCode = 0) or Dependency_List[DependencyIndex].ForceSuccess then begin // ERROR_SUCCESS (0)
+                break;
+              end else if ResultCode = 1641 then begin // ERROR_SUCCESS_REBOOT_INITIATED (1641)
                 NeedsRestart := True;
                 Result := Dependency_List[DependencyIndex].Title;
+                break;
+              end else if ResultCode = 3010 then begin // ERROR_SUCCESS_REBOOT_REQUIRED (3010)
+                Dependency_NeedRestart := True;
+                break;
               end;
-              break;
-            end else if (ResultCode = 0) or Dependency_List[DependencyIndex].ForceSuccess then begin // ERROR_SUCCESS (0)
-              break;
-            end else if ResultCode = 1641 then begin // ERROR_SUCCESS_REBOOT_INITIATED (1641)
-              NeedsRestart := True;
-              Result := Dependency_List[DependencyIndex].Title;
-              break;
-            end else if ResultCode = 3010 then begin // ERROR_SUCCESS_REBOOT_REQUIRED (3010)
-              Dependency_NeedRestart := True;
-              break;
+            end;
+
+            case SuppressibleMsgBox(FmtMessage(SetupMessage(msgErrorFunctionFailed), [Dependency_List[DependencyIndex].Title, IntToStr(ResultCode)]), mbError, MB_ABORTRETRYIGNORE, IDIGNORE) of
+              IDABORT: begin
+                Result := Dependency_List[DependencyIndex].Title;
+                break;
+              end;
+              IDIGNORE: begin
+                break;
+              end;
             end;
           end;
 
-          case SuppressibleMsgBox(FmtMessage(SetupMessage(msgErrorFunctionFailed), [Dependency_List[DependencyIndex].Title, IntToStr(ResultCode)]), mbError, MB_ABORTRETRYIGNORE, IDIGNORE) of
-            IDABORT: begin
-              Result := Dependency_List[DependencyIndex].Title;
-              break;
-            end;
-            IDIGNORE: begin
-              break;
-            end;
+          if Result <> '' then begin
+            break;
           end;
-        end;
-
-        if Result <> '' then begin
-          break;
         end;
       end;
 
@@ -196,6 +280,19 @@ function Dependency_Internal4: Boolean;
 begin
   Result := Dependency_NeedRestart;
 end;
+
+<event('NextButtonClick')>
+function Dependency_NextButtonClick(CurPageID: Integer): boolean;
+begin
+  Dependency_CreateExternalInstallPageIfNeeded;
+  Result := true;
+end;
+
+<event('CancelButtonClick')>
+procedure Dependency_CancelButtonClick(CurPageID: Integer; var Cancel, Confirm: Boolean);
+begin
+  Confirm := (Dependency_ExternalInstallCount = 0) or (CurPageID <> Dependency_ExternalInstallPage.ID);
+end;  
 
 function Dependency_IsX64: Boolean;
 begin
@@ -584,6 +681,11 @@ begin
   end;
 end;
 
+[CustomMessages]
+;http://www.microsoft.com/globaldev/reference/lcid-all.mspx
+en.lcid=1033
+en.externalinstall_title=Missing dependencies
+en.externalinstall_description=The following dependencies are missing on this computer. Please use the associated links to download and install them before running setup again.
 
 [Setup]
 ; -------------


### PR DESCRIPTION
In some cases, an application may require a additional package that cannot be downloaded publicly.
This is for instance the case with Java 1.8 for which a user agreement has to be viewed and agreed before being able to access the download.

This pull request thus introduces the notion of "External install" which, if missing, prevents the setup from continuing until the situation is resolved.