### PR TITLE
Support for .net 4.8.0 - the last supported .net version for Windows7

### DIFF
--- a/CodeDependencies.iss
+++ b/CodeDependencies.iss
@@ -284,7 +284,21 @@ begin
   end;
 end;
 
-procedure Dependency_AddDotNet48;
+procedure Dependency_AddDotNet480;
+var
+  Version: Cardinal;
+begin
+  // https://dotnet.microsoft.com/download/dotnet-framework/net481
+  if not RegQueryDWordValue(HKLM, 'SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full', 'Release', Version) or (Version < 528040) then begin
+    Dependency_Add('dotnetfx48.exe',
+      '/lcid ' + IntToStr(GetUILanguage) + ' /passive /norestart',
+      '.NET Framework 4.8.0',
+      'https://go.microsoft.com/fwlink/?LinkId=2085155',
+      '', False, False);
+  end;
+end;
+
+procedure Dependency_AddDotNet481;
 var
   Version: Cardinal;
 begin


### PR DESCRIPTION
Hi,

.net 4.8.0 is the latest version that runs on Windows7.

Removing/updating it to 4.8.1 causes installer of .net applications that are build for 4.8.0 to break on this system.

I think 4.8.0 should be still supported. Eventually You can leave Dependency_AddDotNet48 for 4.8.1 and higher and allow to choose 4.8.0 explicitly.

