### PR TITLE
Move location of header comment

### DIFF
--- a/CodeDependencies.iss
+++ b/CodeDependencies.iss
@@ -1,7 +1,6 @@
-﻿; https://github.com/DomGries/InnoDependencyInstaller
+﻿[Code]
+// https://github.com/DomGries/InnoDependencyInstaller
 
-
-[Code]
 // types and variables
 type
   TDependency_Entry = record


### PR DESCRIPTION
I have moved the header comment to be after the `[Code]` section heading. This means we can `#include` the script file at the bottom of our own script without encountering compiler errors.