### PR TITLE
fix: new way to check dependency for VC2015To2022.

### DIFF
--- a/ExampleSetup.iss
+++ b/ExampleSetup.iss
@@ -96,7 +96,7 @@ begin
   //Dependency_ForceX86 := True; // force 32-bit install of next dependencies
   Dependency_AddVC2013;
   //Dependency_ForceX86 := False; // disable forced 32-bit install again
-  Dependency_AddVC2015To2022;
+  Dependency_AddVC2015To2022('14.36.32532.0');
 
   //Dependency_AddDirectX;
 


### PR DESCRIPTION
In practice, using msi way to check vc runtime component is installed is not stable. Sometimes using msi based way would run into zombie entry in "HKCR\Installer\UpgradeCodes" which could lead to a runtime error.

Using the ms [documented](https://learn.microsoft.com/en-us/cpp/windows/redistributing-visual-cpp-files?view=msvc-170#install-the-redistributable-packages) way, could be more stable.