### PR TITLE
Be honest about the supported stuff by the vcruntime

### DIFF
--- a/CodeDependencies.iss
+++ b/CodeDependencies.iss
@@ -672,7 +672,7 @@ begin
   end;
 end;
 
-procedure Dependency_AddVC2015To2022;
+procedure Dependency_AddVC2017To2026;
 var
   Version: String;
   PackedVersion: Int64;

--- a/ExampleSetup.iss
+++ b/ExampleSetup.iss
@@ -103,7 +103,7 @@ begin
   //Dependency_ForceX86 := True; // force 32-bit install of next dependencies
   Dependency_AddVC2013;
   //Dependency_ForceX86 := False; // disable forced 32-bit install again
-  Dependency_AddVC2015To2022;
+  Dependency_AddVC2017To2026;
 
   //Dependency_AddDirectX;
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Dependency_Components := ''; // disable component gating again
     * Visual C++ 2010 Service Pack 1 Redistributable
     * Visual C++ 2012 Update 4 Redistributable
     * Visual C++ 2013 Update 5 Redistributable
-    * Visual C++ 2015-2022 Redistributable
+    * Visual C++ 2017-2026 Redistributable
 * SQL
     * SQL Server 2008 R2 Service Pack 2 Express
     * SQL Server 2012 Service Pack 4 Express


### PR DESCRIPTION
This PR renames the VC dependency installer. According to https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist vc2015 is not supported anymore and there is a specific version (much lower than the one installed by InnoDependencyInstaller) which works. So this PR just renames the method to reflect this change. I'm not sure where we could obtain that specific version of the VC runtime that supports 2015.....