### PR TITLE
Forcing 64Bit download via Dependency_ForceX64 := true; did not work

### DIFF
--- a/CodeDependencies.iss
+++ b/CodeDependencies.iss
@@ -239,7 +239,7 @@ end;
 
 function Dependency_IsX64: Boolean;
 begin
-  Result := not Dependency_ForceX86 and Is64BitInstallMode;
+  Result := not Dependency_ForceX86 and (Dependency_ForceX64 or Is64BitInstallMode);
 end;
 
 function Dependency_String(const x86, x64, arm64: String): String;


### PR DESCRIPTION
Forcing 64Bit download via Dependency_ForceX64 := true; did not work

```
    Dependency_ForceX64 := True;
    Dependency_AddDotNet100Desktop;
    Dependency_ForceX64 := False;
```

will now respect the 64 bit and download it, if inno setup is in 32Bit mode